### PR TITLE
Corrected typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ This script will execute `target_script.sh` with various inputs and compare the 
 If you wish to contribute to this project, please fork the repository and submit a pull request. For major changes, please open an issue first to discuss what you would like to change.
 
 # Contact
-For any inquiries or issues, please [contact us](mailtodropress1@gmail.com)
+For any inquiries or issues, please [contact us](mailto:dropress1@gmail.com)


### PR DESCRIPTION
This pull request addresses a typo in the README.md file, specifically in the Contact section. The email link previously read `mailtodropress@gmail.com`, which is incorrect. It has been updated to `mailto:dropress@gmail.com` to ensure proper functionality. 

# Changes made
- Corrected typo in the Contact section of README.md: 
- Changed `mailtodropres@gmail.com` to `mailto:dropress@gmail.com`

# Motivation and Context
This change ensures that the email link in the README.md file functions correctly, allowing users to easily contact us via email. 

# How this has been tested
- Manually verified the correct link to ensure it opens an email client with the correct email address.

# Checklist
- [ - ] l have performed self-review of my own code
- [ - ] My changes generate no new warnings
